### PR TITLE
fix(native): ensure we don't require flipper on iOS if not installed

### DIFF
--- a/flipper-native/ios/FlipperPerformancePlugin.h
+++ b/flipper-native/ios/FlipperPerformancePlugin.h
@@ -1,8 +1,15 @@
 #import <Foundation/Foundation.h>
 
+#if __has_include(<FlipperKit/FlipperPlugin.h>)
 #import <FlipperKit/FlipperPlugin.h>
 #import <React/RCTBridge.h>
 
 @interface FlipperPerformancePlugin : NSObject<RCTBridgeModule, FlipperPlugin>
 
 @end
+
+#else
+@interface FlipperPerformancePlugin : NSObject
+
+@end
+#endif

--- a/flipper-native/ios/FlipperPerformancePlugin.m
+++ b/flipper-native/ios/FlipperPerformancePlugin.m
@@ -1,4 +1,6 @@
 #import "FlipperPerformancePlugin.h"
+
+#if __has_include(<FlipperKit/FlipperPlugin.h>)
 #import <FlipperKit/FlipperConnection.h>
 // This ensures we can use [_bridge dispatchBlock]
 #import <React/RCTBridge+Private.h>
@@ -170,3 +172,11 @@ RCT_REMAP_METHOD(killUIThread,
 }
 
 @end
+
+#else
+
+@implementation FlipperPerformancePlugin
+
+@end
+
+#endif


### PR DESCRIPTION
Should fix #61 

If Flipper isn't installed we expose a dummy version of the Native module to make sure we don't try to import Flipper packages