### PR TITLE
chore: only use Flipper in DEBUG builds

### DIFF
--- a/flipper-native/ios/FlipperPerformancePlugin.h
+++ b/flipper-native/ios/FlipperPerformancePlugin.h
@@ -1,3 +1,5 @@
+#ifdef DEBUG
+
 #import <Foundation/Foundation.h>
 
 #import <FlipperKit/FlipperPlugin.h>
@@ -6,3 +8,5 @@
 @interface FlipperPerformancePlugin : NSObject<RCTBridgeModule, FlipperPlugin>
 
 @end
+
+#endif

--- a/flipper-native/ios/FlipperPerformancePlugin.m
+++ b/flipper-native/ios/FlipperPerformancePlugin.m
@@ -1,3 +1,5 @@
+#ifdef DEBUG
+
 #import "FlipperPerformancePlugin.h"
 #import <FlipperKit/FlipperConnection.h>
 // This ensures we can use [_bridge dispatchBlock]
@@ -170,3 +172,5 @@ RCT_REMAP_METHOD(killUIThread,
 }
 
 @end
+
+#endif


### PR DESCRIPTION
Similarly to https://github.com/facebook/flipper/commit/dd111076c9f6bcfbbc0b0be454b16395dab8fcaf

Just found out that in release mode it still compiles this Pod and I think it's not desired behaviour. If it's desired, then please correct me 😄 